### PR TITLE
Windows configuration auto-reload

### DIFF
--- a/internal/mdathome/options.go
+++ b/internal/mdathome/options.go
@@ -4,6 +4,8 @@
 package mdathome
 
 import (
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -14,5 +16,12 @@ func (c *Cache) getOptions() *bolt.Options {
 }
 
 func prepareConfigurationReload() {
-	// Do absolutely nothing because Windows does not support
+	viper.OnConfigChange(func(e fsnotify.Event) {
+		log.Infof("Configuration updated: %v", viper.AllSettings())
+
+		// Run manual configuration updates
+		//// Update cache limits
+		cache.UpdateCacheLimit(viper.GetInt(KeyCacheSize) * 1024 * 1024)
+	})
+	viper.WatchConfig()
 }


### PR DESCRIPTION
I'm not sure why this wasn't implemented on the Windows build in the first place, since `fsnotify` does work properly on Windows.